### PR TITLE
fix integration test to work against Jubatus 0.8.1

### DIFF
--- a/NOTES.rst
+++ b/NOTES.rst
@@ -1,0 +1,19 @@
+Development Notes
+===================================
+
+To Run Unit Tests
+----------------------------------
+
+```
+./waf build --checkall
+```
+
+To Run Integration Tests
+---------------------------------
+
+Integration tests are written in [jubatest](https://github.com/kmaehashi/jubatest/).
+
+```
+$ source /path/to/jubatest/profile
+$ jubatest --testcase integration_test
+```

--- a/integration_test/test_jubadump.py
+++ b/integration_test/test_jubadump.py
@@ -62,6 +62,7 @@ class JubadumpAnomalyTest(JubaTestCase, JubadumpTestBase):
   def get_config(self):
     config = get_configs(ANOMALY)['lof']
     config['parameter']['method'] = 'inverted_index'
+    config['parameter']['parameter'] = {}
     return (ANOMALY, config)
 
   def do_training(self, target, cli):


### PR DESCRIPTION
When unlearning of recommender inverted_index was introduced in 0.8.1, we added more strict config parameter validation. As a result, jubadump integration tests were not working.