### PR TITLE
Add partial support of Anomaly LOF & Light LOF

### DIFF
--- a/src/jubatus/dump/unsupported.hpp
+++ b/src/jubatus/dump/unsupported.hpp
@@ -1,0 +1,44 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_DUMP_UNSUPPORTED_HPP_
+#define JUBATUS_DUMP_UNSUPPORTED_HPP_
+
+#include <jubatus/util/data/serialization.h>
+
+namespace jubatus {
+namespace dump {
+
+struct unsupported_data {
+  MSGPACK_DEFINE();
+};
+
+struct unsupported_data_dump {
+  const jubatus::util::data::optional<int> null_ptr;
+
+  explicit unsupported_data_dump(const unsupported_data&) {
+  }
+
+  template <class Ar>
+  void serialize(Ar& ar) {
+    ar & JUBA_NAMED_MEMBER("(dump not supported)", null_ptr);
+  }
+};
+
+}  // namespace dump
+}  // namespace jubatus
+
+#endif  // JUBATUS_DUMP_UNSUPPORTED_HPP_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 #include "jubatus/dump/classifier.hpp"
 #include "jubatus/dump/recommender.hpp"
 #include "jubatus/dump/anomaly.hpp"
+#include "jubatus/dump/unsupported.hpp"
 
 using std::runtime_error;
 using jubatus::core::common::read_big_endian;
@@ -154,8 +155,13 @@ int run(const std::string& path) try {
             anomaly_dump<lof<inverted_index>, lof_dump<
                 inverted_index, inverted_index_recommender_dump> > >(m, js);
       } else {
-        throw runtime_error("backend recommender method \"" + backend_method +
-                            "\" is not supported for dump");
+        std::cerr << "Warning: backend recommender method \""
+                  << backend_method << "\" is not supported for dump"
+                  << std::endl;
+        dump<
+            anomaly<lof<unsupported_data> >,
+            anomaly_dump<lof<unsupported_data>, lof_dump<
+                unsupported_data, unsupported_data_dump> > >(m, js);
       }
     } else {
       throw runtime_error("anomaly method \"" + method +

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,8 +164,12 @@ int run(const std::string& path) try {
                 unsupported_data, unsupported_data_dump> > >(m, js);
       }
     } else {
-      throw runtime_error("anomaly method \"" + method +
-                          "\" is not supported for dump");
+      std::cerr << "Warning: anomaly method \""
+                << method << "\" is not fully supported for dump"
+                << std::endl;
+      dump<
+          anomaly<unsupported_data>,
+          anomaly_dump<unsupported_data, unsupported_data_dump> >(m, js);
     }
   } else {
     throw runtime_error("type \"" + m.type_ +


### PR DESCRIPTION
* Allow dumping Anomaly LOF model files with backend other than inverted_index. Note that NN part of the model file is not dumped. For users using euclid_lsh backend, most users are only interested in kdist / lrd of the LOF model, so this is still meaningful to do this.
* Allow dumping Anomaly model files using algorithms other than LOF (i.e., Light LOF); you can only see the weight_manager content.
* A stub class called `unsupported_data` is now added, so you can skip implementing difficult part when adding dumper of other engines / algorithms.