### PR TITLE
support nearest_neighbor dump

### DIFF
--- a/src/jubatus/dump/column_table.cpp
+++ b/src/jubatus/dump/column_table.cpp
@@ -1,0 +1,69 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "column_table.hpp"
+
+#include <string>
+
+#include <msgpack.hpp>
+
+namespace jubatus {
+namespace dump {
+
+column_table_dump::column_table_dump(const column_table& table) {
+  // Extract schema
+  for (size_t col_id = 0; col_id < table.columns_.size(); ++col_id) {
+    column_type t;
+    t.type_ = static_cast<column_type::type_name>(table.columns_[col_id].schema_.first);
+    t.bit_vector_length_ = table.columns_[col_id].schema_.second;
+    schema.push_back(t);
+  }
+
+  // Extract table contents
+  for (size_t row_id = 0; row_id < table.keys_.size(); ++row_id) {
+    std::string key = table.keys_[row_id];
+
+    column_table::index_table::const_iterator it = table.index_.find(key);
+    if (it == table.index_.end()) {
+      throw std::runtime_error("index is broken");
+    }
+
+    uint64_t row_index = it->second;
+    row_entry row;
+    for (size_t col_id = 0; col_id < table.columns_.size(); ++col_id) {
+      std::vector<msgpack::object> v;
+
+      /* For bit_vector values, multiple uint64_t values (blocks) are used to
+         record bit_vector.  For other type of values (e.g., int, string, ...)
+         only consumes 1 block (note that bit_vector_length_ is 0 for them.) */
+      size_t blocks = ((schema[col_id].bit_vector_length_ - 1) / 64) + 1;
+      for (size_t i = 0; i < blocks; ++i) {
+        v.push_back(table.columns_[col_id].data_[row_index + i]);
+      }
+      row.values.push_back(v);
+    }
+    row.owner = table.versions_[row_id].first.name;
+    row.version = table.versions_[row_id].second;
+
+    data[key] = row;
+  }
+
+  // Extract clock
+  clock = table.clock_;
+}
+
+}  // namespace dump
+}  // namespace jubatus

--- a/src/jubatus/dump/column_table.hpp
+++ b/src/jubatus/dump/column_table.hpp
@@ -1,0 +1,161 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_DUMP_COLUMN_TABLE_HPP_
+#define JUBATUS_DUMP_COLUMN_TABLE_HPP_
+
+#include <stdint.h>
+
+#include <string>
+#include <map>
+#include <vector>
+
+#include <msgpack.hpp>
+#include <jubatus/util/data/serialization.h>
+#include <jubatus/util/data/unordered_map.h>
+
+#include "types.hpp"
+#include "msgpack_serializer.hpp"
+
+namespace jubatus {
+namespace dump {
+
+struct owner {
+  std::string name;
+
+  MSGPACK_DEFINE(name);
+};
+
+struct abstract_column {
+  // schema_.first:  column type (enum type_name)
+  // schema_.second: bit_vector length (if column type is a bit_vector)
+  std::pair<uint8_t, uint64_t> schema_;
+
+  // Records: list of value whose type is type_.
+  std::vector<msgpack::object> data_;
+
+  MSGPACK_DEFINE(schema_, data_);
+};
+
+struct column_table {
+  typedef std::pair<owner, uint64_t> version_t;
+  typedef jubatus::util::data::unordered_map<std::string, uint64_t> index_table;
+
+  std::vector<std::string> keys_;
+  uint64_t tuples_;
+  std::vector<version_t> versions_;
+  std::vector<abstract_column> columns_;
+  uint64_t clock_;
+  index_table index_;
+
+  MSGPACK_DEFINE(keys_, tuples_, versions_, columns_, clock_, index_);
+};
+
+struct column_type {
+  // Copied from jubatus/core/storage/column_type.hpp
+
+  enum type_name {
+    int8_type,
+    int16_type,
+    int32_type,
+    int64_type,
+    uint8_type,
+    uint16_type,
+    uint32_type,
+    uint64_type,
+    float_type,
+    double_type,
+    bit_vector_type,
+    string_type,
+    array_type,  // not implemented yet
+    invalid_type
+  };
+
+  std::string type_as_string() const {
+    if (type_ == int8_type) {
+      return "int8";
+    } else if (type_ == int16_type) {
+      return "int16";
+    } else if (type_ == int32_type) {
+      return "int32";
+    } else if (type_ == int64_type) {
+      return "int64";
+    } else if (type_ == uint8_type) {
+      return "uint8";
+    } else if (type_ == uint16_type) {
+      return "uint16";
+    } else if (type_ == uint32_type) {
+      return "uint32";
+    } else if (type_ == uint64_type) {
+      return "uint64";
+    } else if (type_ == float_type) {
+      return "float";
+    } else if (type_ == double_type) {
+      return "double";
+    } else if (type_ == bit_vector_type) {
+      return "bit_vector";
+    } else if (type_ == string_type) {
+      return "string";
+    }
+    throw std::out_of_range("unknown type");
+  }
+
+  type_name type_;
+  int bit_vector_length_;
+
+  template <class Ar>
+  void serialize(Ar& ar) {
+    std::string t = type_as_string();
+    ar
+        & JUBA_NAMED_MEMBER("type", t)
+        & JUBA_NAMED_MEMBER("bit_vector_length", bit_vector_length_);
+  }
+};
+
+struct row_entry {
+  std::vector<std::vector<msgpack::object> > values;  // variant array
+  std::string owner;
+  uint64_t version;
+
+  template <class Ar>
+  void serialize(Ar& ar) {
+    ar
+        & JUBA_MEMBER(values)
+        & JUBA_MEMBER(owner)
+        & JUBA_MEMBER(version);
+  }
+};
+
+struct column_table_dump {
+  explicit column_table_dump(const column_table& table);
+
+  std::vector<column_type> schema;
+  std::map<std::string, row_entry> data;
+  uint64_t clock;
+
+  template <class Ar>
+  void serialize(Ar& ar) {
+    ar
+        & JUBA_MEMBER(schema)
+        & JUBA_MEMBER(data)
+        & JUBA_MEMBER(clock);
+  }
+};
+
+}  // namespace dump
+}  // namespace jubatus
+
+#endif  // JUBATUS_DUMP_COLUMN_TABLE_HPP_

--- a/src/jubatus/dump/msgpack_serializer.hpp
+++ b/src/jubatus/dump/msgpack_serializer.hpp
@@ -1,0 +1,87 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_DUMP_MSGPACK_SERIALIZER_HPP_
+#define JUBATUS_DUMP_MSGPACK_SERIALIZER_HPP_
+
+#include <msgpack.hpp>
+#include <jubatus/util/lang/cast.h>
+#include <jubatus/util/text/json.h>
+
+namespace jubatus {
+namespace util {
+namespace text {
+namespace json {
+
+/**
+ * Extend JSON serializer so that MessagePack objects can be serialized.
+ */
+inline void serialize(json& js, msgpack::object& obj) {
+  switch(obj.type) {
+  case msgpack::type::BOOLEAN: {
+    js = json(new json_bool(obj.via.boolean));
+    break;
+  }
+  case msgpack::type::POSITIVE_INTEGER: {
+    js = json(new json_integer(obj.via.i64));
+    break;
+  }
+  case msgpack::type::NEGATIVE_INTEGER: {
+    js = json(new json_integer(obj.via.u64));
+    break;
+  }
+  case msgpack::type::DOUBLE: {
+    js = json(new json_float(obj.via.dec));
+    break;
+  }
+  case msgpack::type::RAW: {
+    js = json(new json_string(std::string(obj.via.raw.ptr, obj.via.raw.size)));
+    break;
+  }
+  case msgpack::type::ARRAY: {
+    json tmp(new json_array());
+    for (size_t i = 0; i < obj.via.array.size; ++i) {
+      json v;
+      serialize(v, obj.via.array.ptr[i]);
+      tmp.add(v);
+    }
+    js = tmp;
+    break;
+  }
+  case msgpack::type::MAP: {
+    json tmp(new json_object());
+    for (size_t i = 0; i < obj.via.map.size; ++i) {
+      msgpack::object_kv ent = obj.via.map.ptr[i];
+      json v;
+      serialize(v, ent.val);
+      tmp[jubatus::util::lang::lexical_cast<std::string>(ent.key)] = v;
+    }
+    js = tmp;
+    break;
+  }
+  case msgpack::type::NIL: {
+    js = json(new json_null());
+    break;
+  }
+  }  // switch
+}
+
+}  // namespace json
+}  // namespace text
+}  // namespace util
+}  // namespace jubatus
+
+#endif

--- a/src/jubatus/dump/nearest_neighbor.cpp
+++ b/src/jubatus/dump/nearest_neighbor.cpp
@@ -1,0 +1,23 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "nearest_neighbor.hpp"
+
+namespace jubatus {
+namespace dump {
+
+}  // namespace dump
+}  // namespace jubatus

--- a/src/jubatus/dump/nearest_neighbor.hpp
+++ b/src/jubatus/dump/nearest_neighbor.hpp
@@ -1,0 +1,58 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_DUMP_NEAREST_NEIGHBOR_HPP_
+#define JUBATUS_DUMP_NEAREST_NEIGHBOR_HPP_
+
+#include <map>
+#include <string>
+
+#include <jubatus/util/data/serialization.h>
+
+#include "column_table.hpp"
+#include "weight_manager.hpp"
+
+namespace jubatus {
+namespace dump {
+
+struct nearest_neighbor {
+  column_table table;
+  weight_manager weights;
+
+  MSGPACK_DEFINE(table, weights);
+};
+
+struct nearest_neighbor_dump {
+  explicit nearest_neighbor_dump(const nearest_neighbor& nn)
+      : table(nn.table),
+        weights(nn.weights) {
+  }
+
+  column_table_dump table;
+  weight_manager_dump weights;
+
+  template <class Ar>
+  void serialize(Ar& ar) {
+    ar
+        & JUBA_MEMBER(table)
+        & JUBA_MEMBER(weights);
+  }
+};
+
+}  // namespace dump
+}  // namespace jubatus
+
+#endif  // JUBATUS_DUMP_NEAREST_NEIGHBOR_HPP_

--- a/src/jubatus/dump/wscript
+++ b/src/jubatus/dump/wscript
@@ -4,7 +4,9 @@ def build(bld):
             'classifier.cpp',
             'recommender.cpp',
             'anomaly.cpp',
+            'nearest_neighbor.cpp',
             'weight_manager.cpp',
+            'column_table.cpp',
             ],
         target = 'jubatus_dump'
         )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 #include "jubatus/dump/classifier.hpp"
 #include "jubatus/dump/recommender.hpp"
 #include "jubatus/dump/anomaly.hpp"
+#include "jubatus/dump/nearest_neighbor.hpp"
 #include "jubatus/dump/unsupported.hpp"
 
 using std::runtime_error;
@@ -171,6 +172,8 @@ int run(const std::string& path) try {
           anomaly<unsupported_data>,
           anomaly_dump<unsupported_data, unsupported_data_dump> >(m, js);
     }
+  } else if (m.type_ == "nearest_neighbor") {
+    dump<nearest_neighbor, nearest_neighbor_dump>(m, js);
   } else {
     throw runtime_error("type \"" + m.type_ +
                         "\" is not supported for dump");


### PR DESCRIPTION
Support dumping Nearest Neighbor model. (#28)

The dump format is as follows:

```
{
  "weights": {
    "version_number": 0,
    "document_frequencies": {
      "x@num": 1,
      "y@num": 1
    },
    "document_count": 2
  },
  "table": {
    "clock": 2,
    "schema": [
      {
        "bit_vector_length": 250,
        "type": "bit_vector"
      },
      {
        "bit_vector_length": 0,
        "type": "float"
      }
    ],
    "data": {
      "p2": {
        "version": 1,
        "values": [
          [
            5850739868059964045,
            1774212450234407827,
            219746012500552937,
            -5087151512117713177
          ],
          [
            0.800000011921
          ]
        ],
        "owner": "192.168.122.211_9199"
      },
      "p1": {
        "version": 0,
        "values": [
          [
            422525960689092039,
            5850739868059964045,
            1774212450234407827,
            219746012500552937
          ],
          [
            1.20000004768
          ]
        ],
        "owner": "192.168.122.211_9199"
      }
    }
  }
}
```