### PR TITLE
support BM25

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,11 +43,13 @@ Format
 
 - common
 
-  - ``weights``
+  - ``weights`` (some values are available only when IDF/BM25 weighting is used)
 
     - ``version_number`` : Version of model. This value will be updated by MIX.
     - ``document_frequencies`` : Frequency of each feature in data inputted so far.
     - ``document_count`` : Number of all documents. This value will be used in calculation of global_weight(idf).
+    - ``group_frequencies`` : Frequency of each Datum (string_values) key in data inputted so far.
+    - ``group_total_length`` : Number of total features extracted from each Datum (string_values) key in data inputted so far.
 
 - classifier
 

--- a/src/jubatus/dump/types.hpp
+++ b/src/jubatus/dump/types.hpp
@@ -46,9 +46,16 @@ struct counter {
 struct keyword_weights {
   size_t document_count_;
   counter document_frequencies_;
+  counter group_frequencies_;
+  counter group_total_lengths_;
   std::map<std::string, float> weights_;
 
-  MSGPACK_DEFINE(document_count_, document_frequencies_, weights_);
+  MSGPACK_DEFINE(
+      document_count_,
+      document_frequencies_,
+      group_frequencies_,
+      group_total_lengths_,
+      weights_);
 };
 
 struct version {

--- a/src/jubatus/dump/weight_manager.cpp
+++ b/src/jubatus/dump/weight_manager.cpp
@@ -36,37 +36,25 @@ weight_manager_dump::weight_manager_dump(const weight_manager& weights) {
     document_frequencies[it->first] += it->second;
   }
 
-  // group_records (diff)
+  // group_frequencies
+  group_frequencies = weights.master_weights_.group_frequencies_.data_;
   {
-    const std::map<std::string, double>& master_group_freq =
-        weights.master_weights_.group_frequencies_.data_;
-    const std::map<std::string, double>& master_group_length =
-        weights.master_weights_.group_total_lengths_.data_;
-
+    const std::map<std::string, double>& diff_freq =
+        weights.diff_weights_.group_frequencies_.data_;
     for (std::map<std::string, double>::const_iterator
-         it = master_group_freq.begin(); it != master_group_freq.end(); ++it) {
-      // frequency
+        it = diff_freq.begin(); it != diff_freq.end(); ++it) {
       group_frequencies[it->first] += it->second;
-
-      // total length (keys in group_freq must be in group_length)
-      group_total_lengths[it->first] += master_group_length.at(it->first);
     }
   }
 
-  // group records (master)
+  // group_total_lengths
+  group_total_lengths = weights.master_weights_.group_total_lengths_.data_;
   {
-    const std::map<std::string, double>& diff_group_freq =
-        weights.diff_weights_.group_frequencies_.data_;
-    const std::map<std::string, double>& diff_group_length =
+    const std::map<std::string, double>& diff_lengths =
         weights.diff_weights_.group_total_lengths_.data_;
-
     for (std::map<std::string, double>::const_iterator
-         it = diff_group_freq.begin(); it != diff_group_freq.end(); ++it) {
-      // frequency
-      group_frequencies[it->first] += it->second;
-
-      // total length (keys in group_freq must be in group_length)
-      group_total_lengths[it->first] += diff_group_length.at(it->first);
+         it = diff_lengths.begin(); it != diff_lengths.end(); ++it) {
+      group_total_lengths[it->first] += it->second;
     }
   }
 

--- a/src/jubatus/dump/weight_manager.cpp
+++ b/src/jubatus/dump/weight_manager.cpp
@@ -22,9 +22,12 @@ namespace jubatus {
 namespace dump {
 
 weight_manager_dump::weight_manager_dump(const weight_manager& weights) {
+  // document_count
   document_count =
       weights.diff_weights_.document_count_
       + weights.master_weights_.document_count_;
+
+  // document_frequencies
   document_frequencies = weights.master_weights_.document_frequencies_.data_;
   const std::map<std::string, double>&
       diff = weights.diff_weights_.document_frequencies_.data_;
@@ -32,6 +35,42 @@ weight_manager_dump::weight_manager_dump(const weight_manager& weights) {
            it = diff.begin(); it != diff.end(); ++it) {
     document_frequencies[it->first] += it->second;
   }
+
+  // group_records (diff)
+  {
+    const std::map<std::string, double>& master_group_freq =
+        weights.master_weights_.group_frequencies_.data_;
+    const std::map<std::string, double>& master_group_length =
+        weights.master_weights_.group_total_lengths_.data_;
+
+    for (std::map<std::string, double>::const_iterator
+         it = master_group_freq.begin(); it != master_group_freq.end(); ++it) {
+      // frequency
+      group_frequencies[it->first] += it->second;
+
+      // total length (keys in group_freq must be in group_length)
+      group_total_lengths[it->first] += master_group_length.at(it->first);
+    }
+  }
+
+  // group records (master)
+  {
+    const std::map<std::string, double>& diff_group_freq =
+        weights.diff_weights_.group_frequencies_.data_;
+    const std::map<std::string, double>& diff_group_length =
+        weights.diff_weights_.group_total_lengths_.data_;
+
+    for (std::map<std::string, double>::const_iterator
+         it = diff_group_freq.begin(); it != diff_group_freq.end(); ++it) {
+      // frequency
+      group_frequencies[it->first] += it->second;
+
+      // total length (keys in group_freq must be in group_length)
+      group_total_lengths[it->first] += diff_group_length.at(it->first);
+    }
+  }
+
+  // version_number
   version_number = weights.version_.version_number_;
 }
 

--- a/src/jubatus/dump/weight_manager.hpp
+++ b/src/jubatus/dump/weight_manager.hpp
@@ -45,13 +45,17 @@ struct weight_manager_dump {
   uint64_t version_number;
   uint32_t document_count;
   std::map<std::string, double> document_frequencies;
+  std::map<std::string, double> group_frequencies;
+  std::map<std::string, double> group_total_lengths;
 
   template <class Ar>
   void serialize(Ar& ar) {
     ar
         & JUBA_MEMBER(version_number)
         & JUBA_MEMBER(document_count)
-        & JUBA_MEMBER(document_frequencies);
+        & JUBA_MEMBER(document_frequencies)
+        & JUBA_MEMBER(group_frequencies)
+        & JUBA_MEMBER(group_total_lengths);
   }
 };
 

--- a/src/jubatus/dump/weight_manager_test.cpp
+++ b/src/jubatus/dump/weight_manager_test.cpp
@@ -31,7 +31,7 @@ TEST(weight_manager, trivial) {
     jubatus::core::fv_converter::weight_manager wm;
     jubatus::core::common::sfv_t fv;
     fv.push_back(std::make_pair("a", 1));
-    wm.update_weight(fv);
+    wm.update_weight(fv, true, true);
 
     jubatus::core::framework::stream_writer<msgpack::sbuffer> st(buf);
     jubatus::core::framework::jubatus_packer jp(st);


### PR DESCRIPTION
This PR fixes jubadump to support model files generated with Jubatus 0.9.2+, which includes BM25 global weighting support (https://github.com/jubatus/jubatus_core/pull/295).