### PR TITLE
Support Jubatus 1.0 model files

### DIFF
--- a/src/jubatus/dump/classifier_test.cpp
+++ b/src/jubatus/dump/classifier_test.cpp
@@ -35,7 +35,8 @@ TEST(classifier, trivial) {
   msgpack::sbuffer buf;
   {
     jubatus::util::lang::shared_ptr<jubatus::core::storage::storage_base> s
-        = jubatus::core::storage::storage_factory::create_storage("local");
+        = jubatus::core::storage::storage_factory::create_storage(
+            "local_mixture");
 
     s->set3("f1", "k1", jubatus::core::storage::val3_t(1.0, 2.0, 3.0));
 
@@ -49,14 +50,14 @@ TEST(classifier, trivial) {
     msgpack::unpacked msg;
     msgpack::unpack(&msg, buf.data(), buf.size());
     
-    local_storage s;
+    local_storage_mixture s;
     msg.get().convert(&s);
 
-    EXPECT_EQ(1u, s.tbl_.size());
-    EXPECT_EQ(1u, s.tbl_["f1"].size());
-    EXPECT_EQ(1.0, s.tbl_["f1"][0].v1);
-    EXPECT_EQ(2.0, s.tbl_["f1"][0].v2);
-    EXPECT_EQ(3.0, s.tbl_["f1"][0].v3);
+    EXPECT_EQ(1u, s.tbl_diff_.size());
+    EXPECT_EQ(1u, s.tbl_diff_["f1"].size());
+    EXPECT_EQ(1.0, s.tbl_diff_["f1"][0].v1);
+    EXPECT_EQ(2.0, s.tbl_diff_["f1"][0].v2);
+    EXPECT_EQ(3.0, s.tbl_diff_["f1"][0].v3);
   }
 }
 

--- a/src/jubatus/dump/local_storage.cpp
+++ b/src/jubatus/dump/local_storage.cpp
@@ -1,5 +1,5 @@
 // Jubatus: Online machine learning framework for distributed environment
-// Copyright (C) 2013 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
@@ -14,10 +14,12 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#include "classifier.hpp"
+#include "local_storage.hpp"
 
 #include <string>
+#include <map>
 
+#include <jubatus/util/data/serialization.h>
 #include <jubatus/util/data/unordered_map.h>
 
 using jubatus::util::data::unordered_map;

--- a/src/jubatus/dump/local_storage.hpp
+++ b/src/jubatus/dump/local_storage.hpp
@@ -1,0 +1,72 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef JUBATUS_DUMP_LOCAL_STORAGE_HPP_
+#define JUBATUS_DUMP_LOCAL_STORAGE_HPP_
+
+#include <string>
+#include <map>
+
+#include <msgpack.hpp>
+#include <jubatus/util/data/serialization.h>
+
+#include "types.hpp"
+
+namespace jubatus {
+namespace dump {
+
+struct val3_t {
+  double v1;
+  double v2;
+  double v3;
+
+  MSGPACK_DEFINE(v1, v2, v3);
+
+  inline val3_t& operator+=(const val3_t& other) {
+    v1 += other.v1;
+    v2 += other.v2;
+    v3 += other.v3;
+    return *this;
+  }
+
+  template <class Ar>
+  void serialize(Ar& ar) {
+    ar & JUBA_MEMBER(v1) & JUBA_MEMBER(v2) & JUBA_MEMBER(v3);
+  }
+};
+
+struct local_storage {
+  std::map<std::string, std::map<uint64_t, val3_t> > tbl_;
+  key_manager class2id_;
+
+  MSGPACK_DEFINE(tbl_, class2id_);
+};
+
+struct local_storage_dump {
+  explicit local_storage_dump(const local_storage& storage);
+
+  std::map<std::string, std::map<std::string, val3_t> > weight;
+
+  template <class Ar>
+  void serialize(Ar& ar) {
+    ar & JUBA_MEMBER(weight);
+  }
+};
+
+}  // namespace dump
+}  // namespace jubatus
+
+#endif  // JUBATUS_DUMP_LOCAL_STORAGE_HPP_

--- a/src/jubatus/dump/local_storage_mixture.cpp
+++ b/src/jubatus/dump/local_storage_mixture.cpp
@@ -1,0 +1,72 @@
+// Jubatus: Online machine learning framework for distributed environment
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1 as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "local_storage_mixture.hpp"
+
+#include <string>
+#include <map>
+
+#include <jubatus/util/data/serialization.h>
+#include <jubatus/util/data/unordered_map.h>
+
+using jubatus::util::data::unordered_map;
+
+namespace jubatus {
+namespace dump {
+
+local_storage_mixture_dump::local_storage_mixture_dump(
+    const local_storage_mixture& storage) {
+  // master table
+  for (std::map<std::string, std::map<uint64_t, val3_t> >
+           ::const_iterator it = storage.tbl_.begin();
+       it != storage.tbl_.end(); ++it) {
+    const std::string& feature = it->first;
+
+    for (std::map<uint64_t, val3_t>::const_iterator
+             it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
+      jubatus::util::data::unordered_map<uint64_t, std::string>::const_iterator
+          key = storage.class2id_.id2key_.find(it2->first);
+      if (key != storage.class2id_.id2key_.end()) {
+        const std::string& label = key->second;
+        weight[feature][label] = it2->second;
+      } else {
+        throw std::runtime_error("unknown key found in storage");
+      }
+    }
+  }
+
+  // diff table
+  for (std::map<std::string, std::map<uint64_t, val3_t> >
+           ::const_iterator it = storage.tbl_diff_.begin();
+       it != storage.tbl_diff_.end(); ++it) {
+    const std::string& feature = it->first;
+
+    for (std::map<uint64_t, val3_t>::const_iterator
+             it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
+      jubatus::util::data::unordered_map<uint64_t, std::string>::const_iterator
+          key = storage.class2id_.id2key_.find(it2->first);
+      if (key != storage.class2id_.id2key_.end()) {
+        const std::string& label = key->second;
+        weight[feature][label] += it2->second;  // merge diff into master
+      } else {
+        throw std::runtime_error("unknown key found in storage");
+      }
+    }
+  }
+}
+
+}  // namespace dump
+}  // namespace jubatus

--- a/src/jubatus/dump/local_storage_mixture.hpp
+++ b/src/jubatus/dump/local_storage_mixture.hpp
@@ -14,10 +14,41 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#include "nearest_neighbor.hpp"
+#ifndef JUBATUS_DUMP_LOCAL_STORAGE_MIXTURE_HPP_
+#define JUBATUS_DUMP_LOCAL_STORAGE_MIXTURE_HPP_
+
+#include <string>
+#include <map>
+
+#include <msgpack.hpp>
+#include <jubatus/util/data/serialization.h>
+
+#include "types.hpp"
+#include "local_storage.hpp"
 
 namespace jubatus {
 namespace dump {
 
+struct local_storage_mixture {
+  std::map<std::string, std::map<uint64_t, val3_t> > tbl_;
+  key_manager class2id_;
+  std::map<std::string, std::map<uint64_t, val3_t> > tbl_diff_;
+
+  MSGPACK_DEFINE(tbl_, class2id_, tbl_diff_);
+};
+
+struct local_storage_mixture_dump {
+  explicit local_storage_mixture_dump(const local_storage_mixture& storage);
+
+  std::map<std::string, std::map<std::string, val3_t> > weight;
+
+  template <class Ar>
+  void serialize(Ar& ar) {
+    ar & JUBA_MEMBER(weight);
+  }
+};
+
 }  // namespace dump
 }  // namespace jubatus
+
+#endif  // JUBATUS_DUMP_LOCAL_STORAGE_MIXTURE_HPP_

--- a/src/jubatus/dump/regression.hpp
+++ b/src/jubatus/dump/regression.hpp
@@ -27,7 +27,6 @@
 #include "types.hpp"
 #include "weight_manager.hpp"
 #include "local_storage_mixture.hpp"
-#include "regression.hpp"
 
 namespace jubatus {
 namespace dump {

--- a/src/jubatus/dump/regression.hpp
+++ b/src/jubatus/dump/regression.hpp
@@ -1,5 +1,5 @@
 // Jubatus: Online machine learning framework for distributed environment
-// Copyright (C) 2013 Preferred Networks and Nippon Telegraph and Telephone Corporation.
+// Copyright (C) 2016 Preferred Networks and Nippon Telegraph and Telephone Corporation.
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
@@ -14,8 +14,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef JUBATUS_DUMP_CLASSIFIER_HPP_
-#define JUBATUS_DUMP_CLASSIFIER_HPP_
+#ifndef JUBATUS_DUMP_REGRESSION_HPP_
+#define JUBATUS_DUMP_REGRESSION_HPP_
 
 #include <stdint.h>
 
@@ -25,37 +25,34 @@
 #include <jubatus/util/data/serialization.h>
 
 #include "types.hpp"
-#include "local_storage_mixture.hpp"
 #include "weight_manager.hpp"
-#include "labels.hpp"
+#include "local_storage_mixture.hpp"
+#include "regression.hpp"
 
 namespace jubatus {
 namespace dump {
 
-struct linear_classifier {
+struct linear_regression {
   local_storage_mixture storage;
-  labels label_storage;
 
-  MSGPACK_DEFINE(storage, label_storage);
+  MSGPACK_DEFINE(storage);
 };
 
-struct linear_classifier_dump {
-  explicit linear_classifier_dump(const linear_classifier& classifier)
-      : storage(classifier.storage),
-        label(classifier.label_storage) {
+struct linear_regression_dump {
+  explicit linear_regression_dump(const linear_regression& regression)
+      : storage(regression.storage) {
   }
 
   local_storage_mixture_dump storage;
-  labels_dump label;
 
   template <class Ar>
   void serialize(Ar& ar) {
-    ar & JUBA_MEMBER(storage) & JUBA_MEMBER(label);
+    ar & JUBA_MEMBER(storage);
   }
 };
 
 template <typename S>
-struct classifier {
+struct regression {
   typedef S storage_type;
 
   storage_type storage;
@@ -65,13 +62,13 @@ struct classifier {
 };
 
 template <typename S, typename D>
-struct classifier_dump {
+struct regression_dump {
   typedef S storage_type;
   typedef D dump_type;
 
-  explicit classifier_dump(const classifier<S>& classifier)
-      : storage(classifier.storage),
-        weights(classifier.weights) {
+  explicit regression_dump(const regression<S>& regression)
+      : storage(regression.storage),
+        weights(regression.weights) {
   }
 
   dump_type storage;
@@ -86,4 +83,4 @@ struct classifier_dump {
 }  // namespace dump
 }  // namespace jubatus
 
-#endif  // JUBATUS_DUMP_CLASSIFIER_HPP_
+#endif  // JUBATUS_DUMP_REGRESSION_HPP_

--- a/src/jubatus/dump/wscript
+++ b/src/jubatus/dump/wscript
@@ -1,11 +1,11 @@
 def build(bld):
     bld.stlib(
         source = [
-            'classifier.cpp',
             'recommender.cpp',
             'anomaly.cpp',
-            'nearest_neighbor.cpp',
             'weight_manager.cpp',
+            'local_storage.cpp',
+            'local_storage_mixture.cpp',
             'column_table.cpp',
             'labels.cpp',
             ],

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@
 #include "third_party/cmdline/cmdline.h"
 
 #include "jubatus/dump/classifier.hpp"
+#include "jubatus/dump/regression.hpp"
 #include "jubatus/dump/recommender.hpp"
 #include "jubatus/dump/anomaly.hpp"
 #include "jubatus/dump/nearest_neighbor.hpp"
@@ -132,9 +133,16 @@ int run(const std::string& path) try {
                           "\" is not supported for dump");
     }
   } else if (m.type_ == "regression") {
-    // same model data structure as classifier
-    dump<classifier<local_storage>,
-        classifier_dump<local_storage, local_storage_dump> >(m, js);
+    std::string method;
+    from_json<std::string>(m.config_["method"].get(), method);
+    if (method != "NN" && method != "nearest_neighbor" &&
+        method != "cosine" && method != "euclidean") {
+      dump<regression<linear_regression>,
+          regression_dump<linear_regression, linear_regression_dump> >(m, js);
+    } else {
+      throw runtime_error("regression method \"" + method +
+                          "\" is not supported for dump");
+    }
   } else if (m.type_ == "recommender") {
     std::string method;
     from_json<std::string>(m.config_["method"].get(), method);


### PR DESCRIPTION
Fixes #40.

* Separate local_storage dump feature from ``classifier.{cpp,hpp}`` to ``local_storage.{cpp,hpp}``.
* Implement ``local_storage_mixture.{cpp,hpp}``.
* Implement ``regression.hpp``.
* Fix ``main.cpp`` to support regression.
* Remove unused ``nearest_neighbor.cpp`` file.